### PR TITLE
Add Nobara to build.sh's Fedora section

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ dependencies() {
                 dep_install
                 break
             ;;
-            *fedora*)
+            *fedora*|*nobara*)
                 MANAGER_QUERY="dnf list installed"
                 MANAGER_INSTALL="dnf install"
                 DEPS="{meson,gcc,gcc-c++,libX11-devel,glslang,python3-mako,mesa-libGL-devel,libXNVCtrl-devel,dbus-devel}"


### PR DESCRIPTION
This change is due to MangoHUD's dependency checks getting confused due to not recognizing the distribution.